### PR TITLE
add support for multiple loader configs

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,13 @@
  **/
 
 var path = require('path');
+var assign = require('object-assign');
+var utils = require('loader-utils');
 
 module.exports = function(source) {
     this.cacheable();
 
-    var options = this.options.lessImportLoader;
+    var options = getLoaderConfig(this);
 
     var result = source;
 
@@ -18,3 +20,20 @@ module.exports = function(source) {
 
     return result;
 };
+
+/**
+ * Check the loader query and webpack config for loader options. If an option is defined in both places,
+ * the loader query takes precedence.
+ *
+ * @param {Loader} loaderContext
+ * @returns {Object}
+ */
+function getLoaderConfig(loaderContext) {
+    var query = utils.parseQuery(loaderContext.query);
+    var configKey = query.config || 'lessImportLoader';
+    var config = loaderContext.options[configKey] || {};
+
+    delete query.config;
+
+    return assign({}, config, query);
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
   ],
   "author": "Max <liyue4158@gmail.com>",
   "license": "ISC",
-  "dependencies": {},
+  "dependencies": {
+    "loader-utils": "^0.2.12",
+    "object-assign": "^4.0.1"
+  },
   "devDependencies": {
     "expect.js": "^0.3.1",
     "fs-extra": "^0.23.1",

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,9 @@ describe('less-import-loader', function() {
 
         var result2 = require('raw-loader!../!./cases/b/b.less');
         expect(result2).to.contain('@import "../../less/base";');
+
+        var result3 = require('raw-loader!../?config=anotherConfig!./cases/a.less');
+        expect(result3).to.contain('@import "../less/base-another";');
     });
 
 });

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -10,5 +10,8 @@ module.exports = {
     },
     lessImportLoader: {
         base: path.join(process.cwd(), 'test/less/base')
+    },
+    anotherConfig: {
+        base: path.join(process.cwd(), 'test/less/base-another')
     }
 };


### PR DESCRIPTION
Add support for multiple loader configs via less-import?config=anotherConfig
##### webpack.config.js:

```
lessImportLoader: {
    base: path.join(process.cwd(), 'less/base')
},
anotherConfig: {
    base: path.join(process.cwd(), 'sass/base')
},
module: {
    loaders: [
        // using default
        { 
            test: /\.less$/, 
            loader: 'style!css!less!less-import' 
        },
        // using custom config
        { 
            test: /\.scss$/, 
            loader: 'style!css!sass!less-import?config=anotherConfig' 
        }
    ]
}
```

Also, **please consider renaming** the package to something more generic, like `style-import-loader`, as you can see it works with Sass just as well as it works with Less and with the configuration above the naming looks really weird.

Thanks
